### PR TITLE
## [1.0.9+18]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.9+18]
+- README improvements.
+- new arguments inside variables.
+- fixes Locale canonicalization, now uses the Flutter way: en_US instead of en-us
+- fixes Intl generator error when only languageCode_countryCode is defined (without the languageCode only fallback).
+- Much improved RegExp for variable detection in GoogleSheet cells, when GoogleTranslate corrupts the format breaking the generated code.
+- Automatic iOS Info.plist sync with locales (only macos).
+ 
 ## [1.0.8+17]
 - Improved support for `arb` generation based on `intl` standards!
 - Fixed error for clearing unused rows when you have more than one worksheet.

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,7 +1,17 @@
 import 'dart:io';
 
 import 'package:flutter_translation_sheet/src/runner.dart';
+
 Future<void> main(List<String> args) async {
+  // var a = 'Aca hay {{{{123}} items {a} and 3';
+
+  //
+  // var res = _captureGoogleTranslateVar.allMatches(a);
+  // res.forEach((e) {
+  //   var key = e.group(0)!;
+  //   var res2 = key.replaceAll(_replaceAndLeaveDigitVar, '');
+  //   print(res2);
+  // });
+  // print(a);
   exit(await FTSCommandRunner().run(args));
 }
-

--- a/lib/src/io/dart_gen.dart
+++ b/lib/src/io/dart_gen.dart
@@ -29,11 +29,13 @@ void createLocalesFiles(Map<String, Map<String, String>> localesMap) {
       localeMap,
       beautify: true,
     );
-
     /// save dart file.
     if (config.useDartMaps && config.validTranslationFile) {
       /// Dart translation file.
       var data = prettyJson(localeMap);
+      /// cleanup special chars in translated String.
+      data = data.replaceAll(r'$', '\\\$');
+
       var localeInfo = langInfoFromKey(localeName);
       var className = 'Locale${localeName.pascalCase}';
       var fileData = '''
@@ -216,13 +218,11 @@ String _buildTKeyMap({
   var classCanBeConst = false;
   for (var k in map.keys) {
     final v = map[k];
-
     /// special case for @properties n .arb (invalid for dart files)
     if (k.startsWith('@')) {
       trace('Skipping property $k from Keys');
       continue;
     }
-
     /// TODO: find bad characters for the field...
     var fieldName = k.trim().camelCase;
     // fieldName = fieldName.replaceAll(':', '_');

--- a/lib/src/io/env_parser.dart
+++ b/lib/src/io/env_parser.dart
@@ -233,11 +233,16 @@ class EnvConfig {
   String paramOutputPattern1 = '{{';
   String paramOutputPattern2 = '}}';
   bool intlEnabled = false;
+
   // param_output_pattern
   bool useDartMaps = false;
 
+  String get iosDirPath {
+    return p.canonicalize(p.join(configProjectDir, 'ios'));
+  }
+
   String get intlYamlPath {
-    return !intlEnabled ? '' : joinDir([configProjectDir,'l10n.yaml']);
+    return !intlEnabled ? '' : joinDir([configProjectDir, 'l10n.yaml']);
   }
 
   String get inputYamlDir {

--- a/lib/src/io/intl_dart_gen.dart
+++ b/lib/src/io/intl_dart_gen.dart
@@ -3,9 +3,29 @@ import 'package:yaml/yaml.dart';
 
 import '../../flutter_translation_sheet.dart';
 
-const _pluralKeysValid = {'one', 'zero', 'other', 'many', 'few', 'two'};
+// const _pluralKeysValid = {'one', 'zero', 'other', 'many', 'few', 'two'};
 const _pluralMandatory = 'other';
+const _selectorMandatory = 'other';
 const _kPluralSearch = '.plural:';
+const _kSelectorSearch = '.selector:';
+const _errorStringInvalidPlural =
+    '''plural tokens must declare the variable they use, in the form of "plural:variable:". Sample:
+counter:
+  plural:count:
+    zero: no messages
+    one: you have 1 message
+    other: you have {{count}} messages.
+          ''';
+
+const _errorStringInvalidSelector =
+    '''selector tokens must declare the variable they use, in the form of "selector:variable:". Sample:
+welcomeUser:
+  selector:role:
+    admin: Hello admin!
+    manager: Hello manager!
+    other: Hello visitor.
+          ''';
+Map<String, dynamic> metaFallbackProperties = {};
 
 void buildArb(Map<String, Map<String, String>> map) {
   trace('Building arb files');
@@ -18,63 +38,71 @@ void buildArb(Map<String, Map<String, String>> map) {
 But 'arb-dir:' is not define or l10.yaml not found in your target project.
 Please make sure your trconfig.yaml sits in the root of your project, and l10n.yaml as well.''');
   }
+
+  /// look for base locales.
+  var sublist = config.locales.where((element) => element.contains('_'));
+  sublist.forEach((e) {
+    var langCode = e.split('_').first;
+    if(!map.containsKey(langCode)){
+      trace('Adding base langCode: $langCode for arb generation');
+      map[langCode] = map[e]!;
+    }
+  });
+
   for (var localeKey in map.keys) {
+    // trace('my locale key: ', localeKey);
     final output = <String, dynamic>{
       '@@last_modified': DateTime.now().toIso8601String(),
       '@@locale': localeKey,
+      // special case for countryCode, add base language as well zh-tw
       if (appName.isNotEmpty) 'appName': '$appName',
     };
     var localeMap = map[localeKey]!;
     var pluralMaps = <String, dynamic>{};
+    var selectorMaps = <String, dynamic>{};
     // make arb file.
     for (var k in localeMap.keys) {
-      if (k.contains(_kPluralSearch)) {
-        /// take real id.
-        var idx1 = k.indexOf(_kPluralSearch);
-        var targetKey = k.substring(0, idx1);
-        targetKey = targetKey.camelCase;
-        pluralMaps[targetKey] ??= {};
-
-        /// special case
-        var keys = k.split('.');
-        var pluralToken = keys[keys.length - 2];
-        if (!pluralToken.contains(':')) {
-          error(
-              '''plural tokens must declare the variable they use, in the form of "plural:variable:". Sample:
-counter:
-  plural:count:
-    zero: no messages
-    one: you have 1 message
-    other: you have {{count}} messages.
-          ''');
-          continue;
-        }
-        if (!(pluralMaps[targetKey] as Map).containsKey('var')) {
-          // var variableName = pluralToken.split(':').last;
-          pluralMaps[targetKey]['var'] = pluralToken.split(':').last;
-        }
-        var pluralKey = keys.last;
-//         if (!_pluralKeysValid.contains(pluralKey)) {
-//           error('''Invalid plural key detected in "$k"
-//  Valid types: $_pluralKeysValid
-//  Mandatory type: $_pluralMandatory
-// ''');
-//         } else {
-          pluralMaps[targetKey][pluralKey] = localeMap[k];
-        // }
+      if (k.contains(_kSelectorSearch)) {
+        _customModifier(
+          key: k,
+          value: localeMap[k] as String,
+          searchKey: _kSelectorSearch,
+          targetMap: selectorMaps,
+          errorOnVar: _errorStringInvalidSelector,
+          metaVarType: 'String',
+        );
+      } else if (k.contains(_kPluralSearch)) {
+        _customModifier(
+          key: k,
+          value: localeMap[k] as String,
+          searchKey: _kPluralSearch,
+          targetMap: pluralMaps,
+          errorOnVar: _errorStringInvalidPlural,
+          // metaVarType: 'num',
+        );
       } else {
         var newKey = k.camelCase;
         var textValue = localeMap[k]!;
         output[newKey] = textValue;
-        // trace('the key is $k ///// $newKey');
-        _addMetaKey(newKey, textValue, output);
+        _addMetaKey(newKey, textValue, output, metaProperties);
       }
     }
+
     /// add pluralKeys
     for (var k in pluralMaps.keys) {
+      /// add meta keys
       output[k] = _resolvePluralTextFromMap(pluralMaps[k]);
-      _addMetaKey(k, output[k], output);
+      _addMetaKey(k, output[k], output, metaProperties);
+      _addMetaKey(k, output[k], output, metaFallbackProperties);
     }
+
+    /// add selector keys
+    for (var k in selectorMaps.keys) {
+      output[k] = _resolveSelectorTextFromMap(selectorMaps[k]);
+      _addMetaKey(k, output[k], output, metaProperties);
+      _addMetaKey(k, output[k], output, metaFallbackProperties);
+    }
+
     var jsonString = prettyJson(output);
     var outputFilename = 'app_' + localeKey + '.arb';
     var outputPath = joinDir([arbDir, outputFilename]);
@@ -84,41 +112,191 @@ counter:
   // runPubGet();
 }
 
-void _addMetaKey(String newKey, String textValue, Map output) {
+void _customModifier({
+  required String key,
+  required String value,
+  required String searchKey,
+  String? metaVarType,
+  required Map targetMap,
+  required String errorOnVar,
+}) {
+  // _addSelector(key: k, value: localeMap[k], targetMap: selectorMaps, errorOnVar: _errorStringInvalidSelector);
+  // var idx1 = key.indexOf(_kSelectorSearch);
+  var idx1 = key.indexOf(searchKey);
+  var targetKey = key.substring(0, idx1);
+  targetKey = targetKey.camelCase;
+  targetMap[targetKey] ??= {};
+  var keys = key.split('.');
+  var mainToken = keys[keys.length - 2];
+  if (!mainToken.contains(':')) {
+    error(errorOnVar);
+    return;
+  }
+  if (!(targetMap[targetKey] as Map).containsKey('var')) {
+    targetMap[targetKey]['var'] = mainToken.split(':').last;
+  }
+  String varToken = targetMap[targetKey]['var']!;
+  var selectorKey = keys.last;
+  var metaKey = '@' + targetKey;
+  metaFallbackProperties[metaKey] ??= <String, dynamic>{
+    'description': 'Auto-generated for $targetKey',
+  };
+
+  /// get variables from message if any.
+  metaFallbackProperties[metaKey]!['placeholders'] ??= <String, dynamic>{};
+  if (!metaFallbackProperties[metaKey]!['placeholders'].containsKey(varToken)) {
+    var _map = metaFallbackProperties[metaKey]!['placeholders'];
+    _map[varToken] = <String, dynamic>{};
+    if (metaVarType != null) {
+      _map[varToken]!['type'] = metaVarType;
+    }
+  }
+  var _map = metaFallbackProperties[metaKey]!['placeholders'];
+  value = _saveVarsFromString(value, _map);
+  targetMap[targetKey][selectorKey] = value;
+}
+
+void _addMetaKey(String newKey, String textValue, Map output, Map metaMap) {
   /// add description always.
   late Map placeholders;
 
   /// check if the property had metadata.
   final metaKey = '@$newKey';
-  if (metaProperties.containsKey(metaKey)) {
-    output[metaKey] = metaProperties[metaKey];
+  if (metaMap.containsKey(metaKey)) {
+    output[metaKey] = Map.from(metaMap[metaKey]);
+    // trace("Meta map has it! ${metaKey} /// ${metaMap[metaKey]}");
   } else {
     output[metaKey] = <String, dynamic>{};
   }
-  // output[metaKey]['description'] ??= 'This String was assigned in $newKey';
   if (output[metaKey].containsKey('placeholders')) {
     placeholders = {}..addAll(output[metaKey]['placeholders']);
   } else {
     placeholders = {};
-  }
-  if (textValue.contains('{') && textValue.contains('}')) {
-    /// get properties back!
-    var res = _captureArbSet(textValue);
-    if (res.isNotEmpty) {
-      res.forEach((e) {
-        /// if we already have "metaProperties", don't override.
-        if (!placeholders.containsKey(e)) {
-          placeholders[e] = {};
-        }
-      });
+    if (metaMap.containsKey(metaKey) &&
+        metaMap[metaKey].containsKey('placeholders')) {
+      placeholders.addAll(metaMap[metaKey]['placeholders']);
     }
   }
+  _saveVarsFromString(textValue, placeholders);
+}
+
+const _emptyVarMap = <String, dynamic>{};
+
+String _saveVarsFromString(String value, Map saveTo) {
+  final textVars = _varsFromString(value);
+  var cleanedValue = value;
+  if (textVars.isNotEmpty) {
+    textVars.forEach((key, value) {
+      /// take complex {vars:type:format(params)} and replace the value with the simple var name.
+      if (value is Map && value.containsKey('_text')) {
+        cleanedValue = cleanedValue.replaceAll(value['_text'], key);
+        value.remove('_text');
+      }
+      return saveTo.putIfAbsent(key, () => value);
+    });
+  }
+  return cleanedValue;
+}
+
+Map<String, dynamic> _varsFromString(String text) {
+  if (text.contains('{') && text.contains('}')) {
+    var res = _captureArbSet(text);
+    if (res.isNotEmpty) {
+      var output = <String, dynamic>{};
+      res.forEach((e) {
+        /// todo: analyze more data in the var type.
+        if (e.contains(':')) {
+          var propData = _buildMetaVarProperties(e);
+          output[propData['name']] = propData['data'];
+        } else {
+          output[e] = {};
+        }
+      });
+      return output;
+    }
+  }
+  return _emptyVarMap;
+}
+
+/// capture format/type/parameters from a composed variable {{name:String}}.
+Map<String, dynamic> _buildMetaVarProperties(String text) {
+  final parts = text.split(':');
+  final name = parts.removeAt(0).trim();
+  final type = parts.removeAt(0).trim();
+  var vo = <String, dynamic>{
+    'type': type,
+  };
+  if (parts.isNotEmpty) {
+    var msg = parts.join(':');
+    var startIndex = msg.indexOf('(');
+    if (startIndex > -1) {
+      vo['format'] = msg.substring(0, startIndex);
+      var endIndex = msg.lastIndexOf(')');
+      if (endIndex == -1) {
+        endIndex = msg.length;
+      }
+      msg = msg.substring(startIndex + 1, endIndex);
+      if (msg.isNotEmpty) {
+        vo['optionalParameters'] = <String, dynamic>{};
+
+        /// replace the escaped quotes.
+        msg = msg.replaceAll('"', '');
+        var params = msg.split(',');
+        params.forEach((param) {
+          var keyVal = param.split(':');
+          if (keyVal.length > 1) {
+            final key = keyVal[0].trim();
+            final _val = keyVal[1].toLowerCase();
+            late Object? val;
+            if (type == 'num' || type == 'number') {
+              val = num.tryParse(_val) ?? _val;
+            } else if (type == 'int') {
+              val = int.tryParse(_val) ?? _val;
+            } else if (type == 'double' || type == 'float') {
+              val = double.tryParse(_val) ?? _val;
+            } else if (type == 'bool' || type == 'boolean') {
+              val = _val == 'true' || _val == 'yes' || _val != '0';
+            } else {
+              val = _val;
+            }
+            vo['optionalParameters'][key] = val;
+          } else {
+            error('Invalid placeholder format.optionalParameters for $text');
+          }
+        });
+      }
+    } else {
+      vo['format'] = msg;
+    }
+  }
+  vo['_text'] = text;
+  return {
+    'name': name,
+    'data': vo,
+  };
+}
+
+/// Usage based on:
+/// https://github.com/localizely/flutter-intl-vscode/issues/12#issuecomment-618503796
+String _resolveSelectorTextFromMap(Map map) {
+  var str = '';
+  if (!map.containsKey(_selectorMandatory)) {
+    error(
+        'select: keys must contain the type "$_selectorMandatory" as default.');
+  }
+  var varKey = map.remove('var');
+  str += '{$varKey, select, ';
+  for (var k in map.keys) {
+    str += '$k {${map[k]}} ';
+  }
+  str += '}';
+  return str;
 }
 
 String _resolvePluralTextFromMap(Map map) {
   var str = '';
   if (!map.containsKey(_pluralMandatory)) {
-    error('Plural objects must contain the type "other" as default.');
+    error('plural: keys must contain the type "$_pluralMandatory" as default.');
   }
   // =0{No contacts}=1{{howMany} contact}=2{{howMany} contacts}few{{howMany} contacts}many{{howMany} contacts}other{{howMany} contacts}}
   // "{howMany,plural, =0{No contacts}=1{{howMany} contact}=2{{howMany} contacts}few{{howMany} contacts}many{{howMany} contacts}other{{howMany} contacts}}",

--- a/lib/src/io/io.dart
+++ b/lib/src/io/io.dart
@@ -5,5 +5,6 @@ export 'dart_gen.dart';
 export 'env_parser.dart';
 export 'extract_strings.dart';
 export 'intl_dart_gen.dart';
+export 'plist_gen.dart';
 export 'sheet_parser.dart';
 export 'yaml_parser.dart';

--- a/lib/src/io/plist_gen.dart
+++ b/lib/src/io/plist_gen.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:dcli/dcli.dart';
+
+import '../../flutter_translation_sheet.dart';
+
+void addLocalesInPlist() {
+  // replaces locales in the InfoPlist if available (only on Macos)
+  // <key>CFBundleLocalizations</key>
+  // <array>
+  // <string>en</string>
+  // <string>ar</string>
+  // </array>
+  var infoPath = buildPath([config.iosDirPath, 'Runner', 'Info.plist']);
+  if (!exists(infoPath)) {
+    trace('Cant find the project ios folder to update locales. Skipping');
+    return;
+  }
+  if (which('plutil').found) {
+    /// get locales :)
+    var localesString = jsonEncode(config.locales);
+    var cmd =
+        'plutil -replace CFBundleLocalizations -json \'$localesString\' $infoPath';
+    cmd.run;
+    trace('Locales were updated for iOS at $infoPath');
+  }
+}

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -74,12 +74,13 @@ class FTSCommandRunner extends CommandRunner<int> {
     if (config.validTKeyFile) {
       createTKeyFileFromMap(map, save: true, includeToString: true);
     }
-
     createLocalesFiles(localesMap);
     formatDartFiles();
     if (config.intlEnabled) {
       buildArb(localesMap);
     }
+    /// add locales in iOS
+    addLocalesInPlist();
     exit(1);
   }
 
@@ -108,6 +109,8 @@ class FTSCommandRunner extends CommandRunner<int> {
     if (config.intlEnabled) {
       buildArb(localesMap);
     }
+    /// add locales in iOS
+    addLocalesInPlist();
     exit(1);
   }
 }

--- a/lib/src/utils/lang_map.dart
+++ b/lib/src/utils/lang_map.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_translation_sheet/src/utils/utils.dart';
 
 LangInfo langInfoFromKey(String key) {
-  key = normLocale(key);
+  key = normLocale(key, '-').toLowerCase();
   // key = key.replaceAll('_', '-');
   if (!kLangMap.containsKey(key)) {
     print('Language code not found: $key');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_translation_sheet
 description: Flutter Translation Sheet Generator is a simple tool to help you with localization (l10n), using automatic GoogleSheet translations (via GTranslate), generating json & dart files.
-version: 1.0.8+17
+version: 1.0.9+18
 homepage: https://github.com/roipeker/flutter_translation_sheet
 
 executables:
@@ -20,6 +20,7 @@ dependencies:
   collection: ^1.15.0
   io: ^1.0.0
   path: ^1.8.0
+
 dev_dependencies:
   pedantic: ^1.11.1
   build_runner: any


### PR DESCRIPTION
- README improvements.
- new arguments inside variables.
- fixes Locale canonicalization, now uses the Flutter way: en_US instead of en-us
- fixes Intl generator error when only languageCode_countryCode is defined (without the languageCode only fallback).
- Much improved RegExp for variable detection in GoogleSheet cells, when GoogleTranslate corrupts the format breaking the generated code.