### PR TITLE
Fix dependency on waitFor

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   args: ^2.4.2
   collection: ^1.18.0
-  dcli: ^3.0.3
+  dcli: ^4.0.1-alpha.8
   googleapis: ^11.4.0
   googleapis_auth: ^1.4.1
   io: ^1.0.4
@@ -25,12 +25,6 @@ dependencies:
   recase: ^4.1.0
   watcher: ^1.1.0
   yaml: ^3.1.2
-
-## Just to satisfy `dcli` constraints.
-dependency_overrides:
-  pubspec2: ^3.0.0
-  posix: ^5.0.0
-  http: ^1.1.0
 
 dev_dependencies:
   lints: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   googleapis: ^11.4.0
   googleapis_auth: ^1.4.1
   io: ^1.0.4
-  http: ^0.13.5
+  http: ^1.1.2
   path: ^1.8.3
   recase: ^4.1.0
   watcher: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   args: ^2.4.2
   collection: ^1.18.0
-  dcli: ^4.0.1-alpha.8
+  dcli: ^4.0.1-alpha.11
   googleapis: ^11.4.0
   googleapis_auth: ^1.4.1
   io: ^1.0.4


### PR DESCRIPTION
This PR removes the dependency on waitFor to make it compatible with the latest Dart version.

Currenty because of the alpha version of dcli we are getting this console error but arb files still are generated fine.
```
Unhandled exception:
Bad state: stdio is not connected
#0      _ProcessImpl.stdout (dart:io-patch/process_patch.dart:530:19)
#1      _startIsolate.<anonymous closure> (package:dcli/src/process/process/process_in_isolate.dart:89:26)
<asynchronous suspension>
```