### PR TITLE
Updated Android checks for latest gradle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.34]
+## [1.0.35]
 - upgrade min Dart SDK to 3.8.0
 - updated dependencies
 - updated to newer gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.34]
+- upgrade min Dart SDK to 3.8.0
+- updated dependencies
+- updated to newer gradle
+
 ## [1.0.33]
 - upgrade min Dart SDK to 3.2.0
 

--- a/example/test_fsheet.dart
+++ b/example/test_fsheet.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_translation_sheet/src/io/android_gen.dart';
+
+void main() {
+  print('🧪 Running addLocalesInAndroid...');
+  addLocalesInAndroid();
+  print('✅ Done.');
+}

--- a/lib/src/io/android_gen.dart
+++ b/lib/src/io/android_gen.dart
@@ -32,24 +32,21 @@ void _buildAndroidLocales(String dirPath) {
   }
 
   var hasAndroid33 = false;
-  var idx1 = buildGradleString.indexOf('compileSdkVersion');
-  if (idx1 > -1) {
-    var idx2 = buildGradleString.indexOf('\n', idx1);
-    var compileSdkVersion = buildGradleString
-        .substring(idx1 + 'compileSdkVersion '.length, idx2)
-        .trim();
-    if (compileSdkVersion == 'flutter.compileSdkVersion') {
-      /// we don't care.
-    } else {
-      var versionNumber = int.tryParse(compileSdkVersion);
-      if (versionNumber != null) {
-        if (versionNumber >= 33) {
-          hasAndroid33 = true;
-          trace('Android 33+ detected');
-        }
+
+  final sdkRegex = RegExp(r'compileSdk(?:Version)?\s*[=:]?\s*(\S+)');
+  final match = sdkRegex.firstMatch(buildGradleString);
+
+  if (match != null) {
+    final sdkValue = match.group(1);
+    if (sdkValue != null && sdkValue != 'flutter.compileSdkVersion') {
+      final versionNumber = int.tryParse(sdkValue);
+      if (versionNumber != null && versionNumber >= 33) {
+        hasAndroid33 = true;
+        trace('Android 33+ detected');
       }
     }
   }
+
 
   var manifestString = openString(manifestPath);
   if (manifestString.isEmpty) {

--- a/lib/src/io/android_gen.dart
+++ b/lib/src/io/android_gen.dart
@@ -47,7 +47,6 @@ void _buildAndroidLocales(String dirPath) {
     }
   }
 
-
   var manifestString = openString(manifestPath);
   if (manifestString.isEmpty) {
     trace('Can\'t locate AndroidManifest.xml');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_translation_sheet
 description: Flutter Translation Sheet (fts) is a simple tool to help you with
   localization (l10n) generating json, arb and dart files.
-version: 1.0.33
+version: 1.0.35
 maintainer: Rodrigo López (@roipeker)
 homepage: https://github.com/roipeker/flutter_translation_sheet
 repository: https://github.com/roipeker/flutter_translation_sheet/
@@ -16,7 +16,7 @@ environment:
 dependencies:
   args: ^2.4.2
   collection: ^1.18.0
-  dcli: ^4.0.1-alpha.11
+  dcli: ^4.0.5
   googleapis: ^11.4.0
   googleapis_auth: ^1.4.1
   io: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_translation_sheet
 description: Flutter Translation Sheet (fts) is a simple tool to help you with
   localization (l10n) generating json, arb and dart files.
-version: 1.0.34
+version: 1.0.35
 maintainer: Rodrigo López (@roipeker)
 homepage: https://github.com/roipeker/flutter_translation_sheet
 repository: https://github.com/roipeker/flutter_translation_sheet/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_translation_sheet
 description: Flutter Translation Sheet (fts) is a simple tool to help you with
   localization (l10n) generating json, arb and dart files.
-version: 1.0.35
+version: 1.0.34
 maintainer: Rodrigo López (@roipeker)
 homepage: https://github.com/roipeker/flutter_translation_sheet
 repository: https://github.com/roipeker/flutter_translation_sheet/
@@ -11,14 +11,14 @@ executables:
   fts: main
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.8.0
 
 dependencies:
   args: ^2.4.2
   collection: ^1.18.0
-  dcli: ^4.0.5
-  googleapis: ^11.4.0
-  googleapis_auth: ^1.4.1
+  dcli: ^8.4.2
+  googleapis: ^15.0.0
+  googleapis_auth: ^2.0.0
   io: ^1.0.4
   http: ^1.2.0
   path: ^1.9.0
@@ -27,4 +27,4 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^6.0.0


### PR DESCRIPTION
- Updated android_gen.dart to check both for compileSdkVersion (old gradle for android) and compileSdk (newer version). This resolves #35 
- Updated dcli from alpha to stable version. This ensures there are no conflicts with old archive package
- Bumped version to 1.0.35
- Added simple test for addLocalesInAndroid()